### PR TITLE
Add HyperTerm's powermode plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@
 
 - https://github.com/chinchang/code-blast-codemirror
 
+## HyperTerm
+
+- https://github.com/zeit/hyperpower
+
 ## IDEA
 
 - https://github.com/ViceFantasyPlace/activate-power-mode


### PR DESCRIPTION
[Hyperpower](https://github.com/zeit/hyperpower) is just a plugin for [hyperterm](https://hyperterm.org/) that turns on power mode.

I thought it would be nice to have this one here :smile:.
